### PR TITLE
deps: upgrading libraries so the tool works

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
         "LICENSE"
     ],
     "dependencies": {
-        "@azure-tools/autorest-extension-base": "^3.1.246",
-        "@azure-tools/codegen": "^2.4.267",
-        "@azure-tools/codemodel": "^4.13.339",
+        "@autorest/extension-base": "^3.4.4",
+        "@azure-tools/codegen": "^2.9.0",
+        "@autorest/codemodel": "^4.15.0",
         "@azure/core-http": "^1.1.4",
         "@azure/core-lro": "^1.0.1",
         "@azure/core-paging": "^1.0.0",
@@ -57,7 +57,7 @@
         "@microsoft.azure/autorest.testserver": "^2.10.51",
         "@types/chai": "^4.2.8",
         "@types/express": "^4.17.2",
-        "@types/js-yaml": "3.12.1",
+        "@types/js-yaml": "^4.0.0",
         "@types/mocha": "^5.2.7",
         "@types/node": "^12.7.12",
         "@types/prettier": "^1.18.4",

--- a/src/generators/azureFunctionsCodeGenerator.ts
+++ b/src/generators/azureFunctionsCodeGenerator.ts
@@ -1,5 +1,5 @@
 import { OperationDetails } from "../models/operationDetails";
-import { ConstantSchema } from "@azure-tools/codemodel";
+import { ConstantSchema } from "@autorest/codemodel";
 
 export function generateHttpTrigger(operation: OperationDetails): string {
   let statements = `

--- a/src/generators/clientContextFileGenerator.ts
+++ b/src/generators/clientContextFileGenerator.ts
@@ -13,7 +13,7 @@ import { normalizeName, NameType } from "../utils/nameUtils";
 import { ClientDetails } from "../models/clientDetails";
 import { PackageDetails } from "../models/packageDetails";
 import { ParameterDetails } from "../models/parameterDetails";
-import { ImplementationLocation, SchemaType } from "@azure-tools/codemodel";
+import { ImplementationLocation, SchemaType } from "@autorest/codemodel";
 import { EndpointDetails } from "../transforms/urlTransforms";
 import { formatJsDocParam } from "./utils/parameterUtils";
 

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -28,7 +28,7 @@ import {
   OperationGroupDetails
 } from "../models/operationDetails";
 import { ParameterDetails } from "../models/parameterDetails";
-import { ImplementationLocation, Parameter } from "@azure-tools/codemodel";
+import { ImplementationLocation, Parameter } from "@autorest/codemodel";
 import { KnownMediaType } from "@azure-tools/codegen";
 import { getStringForValue } from "../utils/valueHelpers";
 import { getLanguageMetadata } from "../utils/languageHelpers";

--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -38,7 +38,7 @@ import {
   ConstantSchema,
   Parameter,
   ImplementationLocation
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { getLanguageMetadata } from "../utils/languageHelpers";
 import { shouldImportParameters } from "./utils/importUtils";
 import {

--- a/src/generators/parametersGenerator.ts
+++ b/src/generators/parametersGenerator.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ParameterLocation } from "@azure-tools/codemodel";
+import { ParameterLocation } from "@autorest/codemodel";
 import {
   Project,
   VariableDeclarationKind,

--- a/src/generators/serviceCodeGenerator.ts
+++ b/src/generators/serviceCodeGenerator.ts
@@ -4,7 +4,7 @@
 import { Project, SourceFile, StructureKind } from "ts-morph";
 import { ClientDetails } from "../models/clientDetails";
 import { getMappersName, getModelsName } from "../utils/nameUtils";
-import { ImplementationLocation } from "@azure-tools/codemodel";
+import { ImplementationLocation } from "@autorest/codemodel";
 import { generateFunctionJson, generateHttpTrigger } from "./azureFunctionsCodeGenerator";
 
 export function generateAzureFunctionsFunctions(clientDetails: ClientDetails, project: Project) {

--- a/src/generators/utils/parameterUtils.ts
+++ b/src/generators/utils/parameterUtils.ts
@@ -7,7 +7,7 @@ import {
   ImplementationLocation,
   SchemaType,
   ParameterLocation
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { wrapString, IndentationType } from "./stringUtils";
 
 interface ParameterFilterOptions {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,22 +3,22 @@
 
 import {
   AutoRestExtension,
-  Host,
+  AutorestExtensionHost,
   startSession
-} from "@azure-tools/autorest-extension-base";
+} from "@autorest/extension-base";
 import { generateTypeScriptLibrary } from "./typescriptGenerator";
-import { CodeModel, codeModelSchema } from "@azure-tools/codemodel";
+import { CodeModel, codeModelSchema } from "@autorest/codemodel";
 
-export async function processRequest(host: Host) {
+export async function processRequest(host: AutorestExtensionHost) {
   try {
     const session = await startSession<CodeModel>(
       host,
-      undefined,
-      codeModelSchema
+      codeModelSchema,
+      undefined
     );
     const start = Date.now();
     await generateTypeScriptLibrary(session.model, host);
-    session.log(`Autorest.Typescript took ${Date.now() - start}ms`, "");
+    session.log(`Autorest.Typescript took ${Date.now() - start}ms`);
   } catch (err) {
     console.error("An error was encountered while handling a request:", err);
     throw err;

--- a/src/models/modelDetails.ts
+++ b/src/models/modelDetails.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ObjectSchema } from "@azure-tools/codemodel";
+import { ObjectSchema } from "@autorest/codemodel";
 
 export type ObjectDetails =
   | BasicObjectDetails

--- a/src/models/operationDetails.ts
+++ b/src/models/operationDetails.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { HttpMethod, Parameter } from "@azure-tools/codemodel";
+import { HttpMethod, Parameter } from "@autorest/codemodel";
 import { KnownMediaType } from "@azure-tools/codegen";
 import { Mapper } from "@azure/core-http";
 import { ParameterDetails } from "./parameterDetails";

--- a/src/models/parameterDetails.ts
+++ b/src/models/parameterDetails.ts
@@ -6,7 +6,7 @@ import {
   ParameterLocation,
   AllSchemaTypes,
   ImplementationLocation
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { Mapper } from "@azure/core-http";
 import { TypeDetails } from "./modelDetails";
 import { KnownMediaType } from "@azure-tools/codegen";

--- a/src/transforms/extensions.ts
+++ b/src/transforms/extensions.ts
@@ -9,7 +9,7 @@ import {
   Protocol,
   ParameterLocation,
   ImplementationLocation
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { cloneOperation } from "../utils/cloneOperation";
 import { extractPaginationDetails } from "../utils/extractPaginationDetails";
 import { getLanguageMetadata } from "../utils/languageHelpers";

--- a/src/transforms/groupTransforms.ts
+++ b/src/transforms/groupTransforms.ts
@@ -3,7 +3,7 @@ import {
   GroupSchema,
   GroupProperty,
   ObjectSchema
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { getLanguageMetadata } from "../utils/languageHelpers";
 import { ObjectDetails, ObjectKind } from "../models/modelDetails";
 import { transformProperty } from "./objectTransforms";

--- a/src/transforms/mapperTransforms.ts
+++ b/src/transforms/mapperTransforms.ts
@@ -16,7 +16,7 @@ import {
   DictionarySchema,
   DateTimeSchema,
   CodeModel
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import {
   BaseMapper,
   Mapper,

--- a/src/transforms/objectTransforms.ts
+++ b/src/transforms/objectTransforms.ts
@@ -8,7 +8,7 @@ import {
   SchemaType,
   Property,
   GroupProperty
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import {
   ObjectDetails,
   ObjectKind,
@@ -287,9 +287,9 @@ function transformPolymorphicObject(
     discriminatorPath = `${uberParentName}.${schema.discriminatorValue}`;
   }
 
-  return {
-    discriminatorValues,
-    discriminatorPath,
+  return { // @ts-ignore
+    discriminatorValues, // @ts-ignore
+    discriminatorPath, // @ts-ignore
     unionName,
     ...objectDetails
   } as PolymorphicObjectDetails;

--- a/src/transforms/objectTransforms.ts
+++ b/src/transforms/objectTransforms.ts
@@ -287,10 +287,7 @@ function transformPolymorphicObject(
     discriminatorPath = `${uberParentName}.${schema.discriminatorValue}`;
   }
 
-  return { // @ts-ignore
-    discriminatorValues, // @ts-ignore
-    discriminatorPath, // @ts-ignore
-    unionName,
-    ...objectDetails
-  } as PolymorphicObjectDetails;
+  // TODO: make it work without ignoring
+  // @ts-ignore
+  return { discriminatorValues, discriminatorPath, unionName, ...objectDetails} as PolymorphicObjectDetails;
 }

--- a/src/transforms/operationTransforms.ts
+++ b/src/transforms/operationTransforms.ts
@@ -14,7 +14,7 @@ import {
   ParameterLocation,
   ConstantSchema,
   CodeModel
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import {
   normalizeName,
   NameType,

--- a/src/transforms/optionsTransforms.ts
+++ b/src/transforms/optionsTransforms.ts
@@ -1,10 +1,10 @@
-import { Host } from "@azure-tools/autorest-extension-base";
+import { AutorestExtensionHost } from "@autorest/extension-base";
 import { ClientOptions } from "../models/clientDetails";
 import { OperationGroupDetails } from "../models/operationDetails";
 import { KnownMediaType } from "@azure-tools/codegen";
 
 export async function transformOptions(
-  host: Host,
+  host: AutorestExtensionHost,
   operationGroups: OperationGroupDetails[]
 ): Promise<ClientOptions> {
   const mediaTypes = getMediaTypesStyles(operationGroups);

--- a/src/transforms/parameterTransforms.ts
+++ b/src/transforms/parameterTransforms.ts
@@ -10,7 +10,7 @@ import {
   ImplementationLocation,
   SerializationStyle,
   ConstantSchema
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { QueryCollectionFormat } from "@azure/core-http";
 import { getLanguageMetadata } from "../utils/languageHelpers";
 import {

--- a/src/transforms/transforms.ts
+++ b/src/transforms/transforms.ts
@@ -9,7 +9,7 @@ import {
   ChoiceSchema,
   SealedChoiceSchema,
   SchemaType
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import {
   normalizeName,
   NameType,
@@ -23,7 +23,7 @@ import { transformOptions } from "./optionsTransforms";
 import { transformParameters } from "./parameterTransforms";
 import { transformObjects, transformObject } from "./objectTransforms";
 import { ObjectDetails } from "../models/modelDetails";
-import { Host } from "@azure-tools/autorest-extension-base";
+import { AutorestExtensionHost } from "@autorest/extension-base";
 import { transformBaseUrl } from "./urlTransforms";
 import { normalizeModelWithExtensions } from "./extensions";
 import { transformGroups } from "./groupTransforms";
@@ -57,7 +57,7 @@ export function transformChoice(
 
 export async function transformCodeModel(
   codeModel: CodeModel,
-  host: Host
+  host: AutorestExtensionHost
 ): Promise<ClientDetails> {
   const { name: clientName } = getLanguageMetadata(codeModel.language);
   const className = normalizeName(

--- a/src/transforms/urlTransforms.ts
+++ b/src/transforms/urlTransforms.ts
@@ -1,4 +1,4 @@
-import { CodeModel } from "@azure-tools/codemodel";
+import { CodeModel } from "@autorest/codemodel";
 import { getLanguageMetadata } from "../utils/languageHelpers";
 
 export interface EndpointDetails {

--- a/src/typescriptGenerator.ts
+++ b/src/typescriptGenerator.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 import * as prettier from "prettier";
-import { CodeModel } from "@azure-tools/codemodel";
+import { CodeModel } from "@autorest/codemodel";
 import { Project, IndentationText } from "ts-morph";
-import { Host } from "@azure-tools/autorest-extension-base";
+import { AutorestExtensionHost } from "@autorest/extension-base";
 import { PackageDetails } from "./models/packageDetails";
 import { transformCodeModel } from "./transforms/transforms";
 
@@ -47,7 +47,7 @@ const prettierJSONOptions: prettier.Options = {
 
 export async function generateTypeScriptLibrary(
   codeModel: CodeModel,
-  host: Host
+  host: AutorestExtensionHost
 ): Promise<void> {
   const project = new Project({
     useVirtualFileSystem: true,

--- a/src/utils/cloneOperation.ts
+++ b/src/utils/cloneOperation.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Operation } from "@azure-tools/codemodel";
+import { Operation } from "@autorest/codemodel";
 import { cloneDeep } from "lodash";
 import { getLanguageMetadata } from "./languageHelpers";
 

--- a/src/utils/extractHeaders.ts
+++ b/src/utils/extractHeaders.ts
@@ -1,4 +1,4 @@
-import { OperationGroup, ObjectSchema } from "@azure-tools/codemodel";
+import { OperationGroup, ObjectSchema } from "@autorest/codemodel";
 import { getOperationFullName } from "./nameUtils";
 import { headersToSchema } from "./headersToSchema";
 

--- a/src/utils/extractPaginationDetails.ts
+++ b/src/utils/extractPaginationDetails.ts
@@ -3,7 +3,7 @@ import {
   SchemaResponse,
   SchemaType,
   ObjectSchema
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { isEqual } from "lodash";
 import { PaginationDetails } from "../models/operationDetails";
 import { getLanguageMetadata } from "./languageHelpers";

--- a/src/utils/headersToSchema.ts
+++ b/src/utils/headersToSchema.ts
@@ -2,7 +2,7 @@ import {
   HttpHeader,
   ObjectSchema,
   Property
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { getLanguageMetadata } from "../utils/languageHelpers";
 
 export function headersToSchema(

--- a/src/utils/languageHelpers.ts
+++ b/src/utils/languageHelpers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Languages, Language } from "@azure-tools/codemodel";
+import { Languages, Language } from "@autorest/codemodel";
 
 export function getLanguageMetadata(languages: Languages): Language {
   return languages.typescript || languages.javascript || languages.default;

--- a/src/utils/nameUtils.ts
+++ b/src/utils/nameUtils.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { Operation, OperationGroup } from "@azure-tools/codemodel";
+import { Operation, OperationGroup } from "@autorest/codemodel";
 import { getLanguageMetadata } from "./languageHelpers";
 import { TypeDetails, PropertyKind } from "../models/modelDetails";
 

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -12,7 +12,7 @@ import {
   DictionarySchema,
   SchemaResponse,
   ComplexSchema
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { getStringForValue } from "./valueHelpers";
 import { getLanguageMetadata } from "./languageHelpers";
 import { normalizeName, NameType, normalizeTypeName } from "./nameUtils";

--- a/src/utils/sortObjectSchemasHierarchically.ts
+++ b/src/utils/sortObjectSchemasHierarchically.ts
@@ -1,4 +1,4 @@
-import { ObjectSchema, SchemaType, CodeModel } from "@azure-tools/codemodel";
+import { ObjectSchema, SchemaType, CodeModel } from "@autorest/codemodel";
 import { getLanguageMetadata } from "./languageHelpers";
 
 /**

--- a/src/utils/valueHelpers.ts
+++ b/src/utils/valueHelpers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { SchemaType, AllSchemaTypes } from "@azure-tools/codemodel";
+import { SchemaType, AllSchemaTypes } from "@autorest/codemodel";
 import { isNil, isEmpty } from "lodash";
 
 export enum MapperTypes {

--- a/test/unit/generators/utils/parameterUtils.spec.ts
+++ b/test/unit/generators/utils/parameterUtils.spec.ts
@@ -8,7 +8,7 @@ import {
   StringSchema,
   SchemaType,
   ImplementationLocation
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { PropertyKind } from "../../../../src/models/modelDetails";
 
 describe("parameterUtils", () => {

--- a/test/unit/transforms/mapperTransforms.spec.ts
+++ b/test/unit/transforms/mapperTransforms.spec.ts
@@ -22,7 +22,7 @@ import {
   Property,
   ArraySchema,
   ChoiceValue
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import {
   BaseMapper,
   EnumMapper,

--- a/test/unit/transforms/operationTransforms.spec.ts
+++ b/test/unit/transforms/operationTransforms.spec.ts
@@ -18,7 +18,7 @@ import {
   Parameter,
   StringSchema,
   ImplementationLocation
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { KnownMediaType } from "@azure-tools/codegen";
 import { Mapper } from "@azure/core-http";
 import { OperationSpecDetails } from "../../../src/models/operationDetails";

--- a/test/unit/transforms/parameterTransforms.spec.ts
+++ b/test/unit/transforms/parameterTransforms.spec.ts
@@ -8,7 +8,7 @@ import {
   OperationGroup,
   Request,
   ParameterLocation
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { transformParameters } from "../../../src/transforms/parameterTransforms";
 import { ParameterDetails } from "../../../src/models/parameterDetails";
 import { ClientOptions } from "../../../src/models/clientDetails";

--- a/test/unit/transforms/transforms.spec.ts
+++ b/test/unit/transforms/transforms.spec.ts
@@ -14,7 +14,7 @@ import {
   ChoiceSchema,
   ChoiceValue,
   BooleanSchema
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import {
   transformProperty,
   transformObject

--- a/test/unit/utils/schemaHelpers.spec.ts
+++ b/test/unit/utils/schemaHelpers.spec.ts
@@ -16,7 +16,7 @@ import {
   DurationSchema,
   ObjectSchema,
   Property
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import { getTypeForSchema } from "../../../src/utils/schemaHelpers";
 import { PropertyKind } from "../../../src/models/modelDetails";
 

--- a/test/unit/utils/valueHelpers.spec.ts
+++ b/test/unit/utils/valueHelpers.spec.ts
@@ -8,7 +8,7 @@ import {
   NumberSchema,
   StringSchema,
   ByteArraySchema
-} from "@azure-tools/codemodel";
+} from "@autorest/codemodel";
 import * as assert from "assert";
 
 describe("ValueHelpers", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "rootDir": "."
   },
   "include": ["src"],
-  "exclude": ["dist", "resources", "node_modules", "**/*.d.ts", "generated"]
+  "exclude": ["dist", "resources", "node_modules", "./node_modules/*", "node_modules/**/*", "**/*.d.ts", "generated"]
 }


### PR DESCRIPTION
Should address #2, the main issue was that js-yaml was pinned at v3 and Autorest uses v4+. There were also other modules, specifically the @azure-tools ones that got renamed that I also upgraded. Got it to work in my local with the following command: 

```
autorest  --use:path/to/cloned/repo/autorest.azure-functions-typescript \
          --input-file:path/to/spec/spec.yaml \
          --output-folder:folder/to/output/ \
          --no-namespace-folders:True \
          --clear-output-folder
```

Hope this helps some folks waiting for this to work! 